### PR TITLE
add vm snapshot for clodutower terraform provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ website/vendor
 
 # Keep windows files with windows line endings
 *.winfile eol=crlf
+
+vendor
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,70 @@
-version = 0.1.0
+version = 0.1.4
+GOOS =
+GOARCH = 
+exeExtension =
+ifeq ($(OS),Windows_NT)
+	GOOS = windows
+	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
+		GOARCH = amd64
+	else ifeq ($(PROCESSOR_ARCHITECTURE),IA64)
+		GOARCH = amd64
+	else ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+		GOARCH = 386
+	endif
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		GOOS = linux
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		GOOS = darwin
+	endif
+	UNAME_P := $(shell uname -p)
+	ifeq ($(UNAME_P),) 
+		UNAME_P = $(shell uname -m)
+	else ifeq ($(UNAME_P),unknown)
+		UNAME_P = $(shell uname -m)
+	endif
+	ifeq ($(UNAME_P),x86_64)
+		GOARCH = amd64
+	endif
+	ifneq ($(filter %86,$(UNAME_P)),)
+		GOARCH = 386
+	endif
+	ifneq ($(filter arm%,$(UNAME_P)),)
+		ifeq ($(GOARCH),386)
+			GOARCH = arm
+		else
+			GOARCH = arm64
+		endif
+	endif
+endif
+
+ifndef GOOS
+	$(error GOOS is not set)
+endif
+ifndef GOARCH
+	$(error GOARCH is not set)
+endif
+
+BuildTarget = 
+LocalRegistry = 
+MkdirCmd = 
+MvCmd = 
+CleanRegistryCmd = 
+ifeq ($(GOOS),windows)
+	BuildTarget = .\bin\terraform-provider-cloudtower.exe
+	LocalRegistry = $(APPDATA)\terraform.d\plugins\registry.terraform.io\smartx\cloudtower\$(version)\$(GOOS)_$(GOARCH)
+	MkdirCmd = mkdir $(LocalRegistry)
+	MvCmd = move $(BuildTarget) $(LocalRegistry)
+	CleanRegistryCmd = if exist "$(LocalRegistry)" rmdir /S /Q $(LocalRegistry)
+else
+	BuildTarget = ./bin/terraform-provider-cloudtower
+	LocalRegistry = ~/.terraform.d/plugins/registry.terraform.io/smartx/cloudtower/$(version)/$(GOOS)_$(GOARCH)/
+	MkdirCmd = mkdir -p $(LocalRegistry)
+	MvCmd = mv $(BuildTarget) $(LocalRegistry)
+	CleanRegistryCmd = if [ -d "$(LocalRegistry)" ]; then rm -rf $(LocalRegistry); fi
+endif
 
 fmt: ## Run go fmt against code.
 	go fmt ./...
@@ -12,9 +78,12 @@ vendor: ## Run go mod vendor against code.
 tidy:  ## Run tidy against code.
 	go mod tidy
 
-build: fmt  ## Build binary.
-	go build -o ./bin/terraform-provider-cloudtower main.go
+clean: ## Remove all build artifacts.
+	$(CleanRegistryCmd)
+	$(MkdirCmd)
+
+build: fmt clean ## Build binary.
+	go build -o $(BuildTarget) main.go
 
 install: build ## Run a controller from your host.
-	mkdir -p ~/.terraform.d/plugins/registry.terraform.io/Yuyz0112/cloudtower/0.1.3/darwin_arm64
-	mv ./bin/terraform-provider-cloudtower ~/.terraform.d/plugins/registry.terraform.io/Yuyz0112/cloudtower/0.1.3/darwin_arm64/
+	$(MvCmd)

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.16
 require (
 	github.com/go-openapi/runtime v0.23.1
 	github.com/go-openapi/strfmt v0.21.2
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-log v0.2.1 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/smartxworks/cloudtower-go-sdk v1.9.0
+	github.com/smartxworks/cloudtower-go-sdk v1.9.1-0.20220419014325-200e33a371f0
 )

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/smartxworks/cloudtower-go-sdk v1.9.0 h1:3DsBmsxLSUU2y7HLVvCDsynq9Xkg7Kp8qeB+FcAd6/U=
-github.com/smartxworks/cloudtower-go-sdk v1.9.0/go.mod h1:hkH2NrYZ7X42gmrZeLMXEEcBLgReerD2SiP4KAj1A24=
+github.com/smartxworks/cloudtower-go-sdk v1.9.1-0.20220419014325-200e33a371f0 h1:Eht3RtRvHkhRXmzeXgmNUV1lq2GS8E5z2Otky2Klhkg=
+github.com/smartxworks/cloudtower-go-sdk v1.9.1-0.20220419014325-200e33a371f0/go.mod h1:hkH2NrYZ7X42gmrZeLMXEEcBLgReerD2SiP4KAj1A24=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/internal/provider/data_source_vm_snapshot.go
+++ b/internal/provider/data_source_vm_snapshot.go
@@ -1,0 +1,104 @@
+package provider
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-cloudtower/internal/cloudtower"
+	"github.com/smartxworks/cloudtower-go-sdk/client/vm_snapshot"
+	"github.com/smartxworks/cloudtower-go-sdk/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceVmSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Description: "CloudTower vm snapshot data source.",
+
+		ReadContext: dataSourceVmSnapshotRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "vm snapshot's name",
+			},
+			"name_contains": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "filter vm snapshot by its name contains characters",
+			},
+			"vm_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "vm's id of the snapshot",
+			},
+			"vm_snapshots": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "list of queried vm snapshots",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "snapshots's id",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "snapshot's name",
+						},
+						"create_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "snapshot's create_time",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVmSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	ct := meta.(*cloudtower.Client)
+
+	gp := vm_snapshot.NewGetVMSnapshotsParams()
+	gp.RequestBody = &models.GetVMSnapshotsRequestBody{
+		Where:   &models.VMSnapshotWhereInput{},
+		OrderBy: models.VMSnapshotOrderByInputLocalCreatedAtASC.Pointer(),
+	}
+	if name := d.Get("name").(string); name != "" {
+		gp.RequestBody.Where.Name = &name
+	} else if nameContains := d.Get("name_contains").(string); nameContains != "" {
+		gp.RequestBody.Where.NameContains = &nameContains
+	}
+	if vm_id := d.Get("vm_id").(string); vm_id != "" {
+		gp.RequestBody.Where.VM.ID = &vm_id
+	}
+	clusters, err := ct.Api.VMSnapshot.GetVMSnapshots(gp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	output := make([]map[string]interface{}, 0)
+	for _, d := range clusters.Payload {
+		output = append(output, map[string]interface{}{
+			"id":          d.ID,
+			"name":        d.Name,
+			"create_time": d.LocalCreatedAt,
+		})
+	}
+	err = d.Set("vm_snapshots", output)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+
+	return diags
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -56,17 +56,19 @@ func New(version string) func() *schema.Provider {
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
-				"cloudtower_datacenter": dataSourceDatacenter(),
-				"cloudtower_cluster":    dataSourceCluster(),
-				"cloudtower_vlan":       dataSourceVlan(),
-				"cloudtower_iso":        dataSourceIso(),
-				"cloudtower_host":       dataSourceHost(),
-				"cloudtower_vm":         dataSourceVm(),
+				"cloudtower_datacenter":  dataSourceDatacenter(),
+				"cloudtower_cluster":     dataSourceCluster(),
+				"cloudtower_vlan":        dataSourceVlan(),
+				"cloudtower_iso":         dataSourceIso(),
+				"cloudtower_host":        dataSourceHost(),
+				"cloudtower_vm":          dataSourceVm(),
+				"cloudtower_vm_snapshot": dataSourceVmSnapshot(),
 			},
 			ResourcesMap: map[string]*schema.Resource{
-				"cloudtower_datacenter": resourceDatacenter(),
-				"cloudtower_cluster":    resourceCluster(),
-				"cloudtower_vm":         resourceVm(),
+				"cloudtower_datacenter":  resourceDatacenter(),
+				"cloudtower_cluster":     resourceCluster(),
+				"cloudtower_vm":          resourceVm(),
+				"cloudtower_vm_snapshot": resourceVmSnapshot(),
 			},
 		}
 

--- a/internal/provider/resource_vm_snapshot.go
+++ b/internal/provider/resource_vm_snapshot.go
@@ -1,0 +1,149 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-provider-cloudtower/internal/cloudtower"
+	"github.com/smartxworks/cloudtower-go-sdk/client/vm_snapshot"
+	"github.com/smartxworks/cloudtower-go-sdk/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceVmSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Description: "CloudTower vm snapshot resource",
+
+		CreateContext: resourceVmSnapshotCreate,
+		ReadContext:   resourceVmSnapshotRead,
+		DeleteContext: resourceVmSnapshotDelete,
+
+		Schema: map[string]*schema.Schema{
+			"vm_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The id of vm to the snapshot belongs to",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of snapshot",
+			},
+			"consistent_type": {
+				Type:        schema.TypeString,
+				Default:     string(models.ConsistentTypeCRASHCONSISTENT),
+				ForceNew:    true,
+				Optional:    true,
+				Description: "The consistent type of snapshot",
+				ValidateDiagFunc: func(v interface{}, _ cty.Path) diag.Diagnostics {
+					var diags diag.Diagnostics
+					val, ok := v.(string)
+					if !ok {
+						return append(diags, diag.Diagnostic{
+							Severity: diag.Error,
+							Summary:  "Wrong type",
+							Detail:   "Consistent type should be a string",
+						})
+					} else if val != string(models.ConsistentTypeCRASHCONSISTENT) && val != string(models.ConsistentTypeFILESYSTEMCONSISTENT) {
+						return append(diags, diag.Diagnostic{
+							Severity: diag.Error,
+							Summary:  "Invalid consistent type",
+							Detail: fmt.Sprintf("Consistent type should be one of %v, but get %s",
+								[]string{string(models.ConsistentTypeCRASHCONSISTENT), string(models.ConsistentTypeFILESYSTEMCONSISTENT)},
+								val,
+							),
+						})
+					}
+					return diags
+				},
+			},
+		},
+	}
+}
+
+func resourceVmSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	ct := meta.(*cloudtower.Client)
+	cvsp := vm_snapshot.NewCreateVMSnapshotParams()
+	consistent_type := models.ConsistentType(d.Get("consistent_type").(string))
+	name := d.Get("name").(string)
+	vm_id := d.Get("vm_id").(string)
+	cvsp.RequestBody = &models.VMSnapshotCreationParams{
+		Data: []*models.VMSnapshotCreationParamsDataItems0{
+			{
+				ConsistentType: &consistent_type,
+				Name:           &name,
+				VMID:           &vm_id,
+			},
+		},
+	}
+	snapshots, err := ct.Api.VMSnapshot.CreateVMSnapshot(cvsp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(*snapshots.Payload[0].Data.ID)
+	_, err = ct.WaitTasksFinish([]string{*snapshots.Payload[0].TaskID})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceVmSnapshotRead(ctx, d, meta)
+}
+
+func resourceVmSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	ct := meta.(*cloudtower.Client)
+
+	id := d.Id()
+	gvsp := vm_snapshot.NewGetVMSnapshotsParams()
+	gvsp.RequestBody = &models.GetVMSnapshotsRequestBody{
+		Where: &models.VMSnapshotWhereInput{
+			ID: &id,
+		},
+	}
+	vmSnapshots, err := ct.Api.VMSnapshot.GetVMSnapshots(gvsp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if len(vmSnapshots.Payload) < 1 {
+		d.SetId("")
+		return diags
+	}
+	snapshot := vmSnapshots.Payload[0]
+	if err := d.Set("consistent_type", snapshot.ConsistentType); err != nil {
+		return diag.FromErr(err)
+	}
+	return diags
+}
+
+func resourceVmSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	ct := meta.(*cloudtower.Client)
+	dvsp := vm_snapshot.NewDeleteVMSnapshotParams()
+	id := d.Id()
+	dvsp.RequestBody = &models.VMSnapshotDeletionParams{
+		Where: &models.VMSnapshotWhereInput{
+			ID: &id,
+		},
+	}
+	snapshots, err := ct.Api.VMSnapshot.DeleteVMSnapshot(dvsp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	taskIds := make([]string, 0)
+	for _, c := range snapshots.Payload {
+		if c.TaskID != nil {
+			taskIds = append(taskIds, *c.TaskID)
+		}
+	}
+	_, err = ct.WaitTasksFinish(taskIds)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId("")
+	return diags
+}


### PR DESCRIPTION
- add vm snapshot resource and datasource
- add rollback vm function
- add rebuild vm from snapshot
- update vm resource:
    - set some config as optional, they may get from vm snapshot
    - set optional config as computed as they may get from snapshot (both for vm updation)
    - fix zero value problem
    
TODO: 
- test vm update after default value of cpu_cores and sockets been fixed

example hcl (github not support tf file, use txt to upload it, rename it):
[hcl.txt](https://github.com/smartxworks/cloudtower-terraform-provider/files/8517845/hcl.txt)

